### PR TITLE
feat: object-level if/then/else conditionals

### DIFF
--- a/Sources/JSONSchemaForm/Fields/ObjectField.swift
+++ b/Sources/JSONSchemaForm/Fields/ObjectField.swift
@@ -14,27 +14,88 @@ struct ObjectField: Field {
 
     @Environment(\.formTemplates) private var templates
 
+    /// Conditionals (`if`/`then`/`else`) declared on THIS object schema,
+    /// extracted from the raw schema JSON at init and delivered through the
+    /// uiSchema side-channel (`__objectConditionals`), keyed by field ID.
+    private var localConditionals: [ConditionalSchema] {
+        guard let map = uiSchema?["__objectConditionals"] as? [String: [ConditionalSchema]] else {
+            return []
+        }
+        return map[id] ?? []
+    }
+
+    /// The `then`/`else` branch schemas whose conditions currently match this
+    /// object's own form data.
+    private var activeBranchSchemas: [[String: Any]] {
+        let conditionals = localConditionals
+        guard !conditionals.isEmpty else { return [] }
+        return ConditionEvaluator.getApplicableSchemas(
+            conditionals: conditionals,
+            formData: formData.wrappedValue
+        )
+    }
+
+    /// Property names declared only in non-matching conditional branches.
+    /// These must not render — not even through the custom-widget ui:order
+    /// fallback below. Their values are intentionally kept in formData so a
+    /// hidden field's value is restored when the condition flips back.
+    private var hiddenConditionalKeys: Set<String> {
+        let conditionals = localConditionals
+        guard !conditionals.isEmpty else { return [] }
+        var declared: Set<String> = []
+        for conditional in conditionals {
+            for branch in [conditional.thenSchema, conditional.elseSchema] {
+                if let props = branch?["properties"] as? [String: Any] {
+                    declared.formUnion(props.keys)
+                }
+            }
+        }
+        var visible = Set((schema.objectSchema?.properties ?? [:]).keys)
+        visible.formUnion(SchemaMerger.getPropertyNamesFromConditionals(activeBranchSchemas))
+        return declared.subtracting(visible)
+    }
+
     // Extract properties from schema, using ui:order or JSON-defined order when available
     private var properties: OrderedDictionary<String, JSONSchema>? {
         guard case .object = schema.type else {
             return nil
         }
 
-        let dict = schema.objectSchema?.properties ?? [:]
+        var dict = schema.objectSchema?.properties ?? [:]
+        // Merge properties from matching conditional branches (branch wins —
+        // it is the more specific schema, mirroring AllOfField's merge).
+        for branch in activeBranchSchemas {
+            guard let props = branch["properties"] as? [String: Any] else { continue }
+            for (name, raw) in props {
+                if let rawSchema = raw as? [String: Any],
+                    let parsed = SchemaMerger.parsePropertySchema(rawSchema, name: name)
+                {
+                    dict[name] = parsed
+                }
+            }
+        }
+        let hidden = hiddenConditionalKeys
 
         // Priority: 1. ui:order from uiSchema, 2. JSON-defined order, 3. dictionary iteration order
         let orderedKeys: [String]
         if let uiOrder = uiSchema?["ui:order"] as? [String] {
             // Use ui:order from uiSchema. Keys missing from schema can still render
-            // when they declare a custom widget in uiSchema.
-            let orderedFromUi = uiOrder.filter { dict.keys.contains($0) || hasCustomWidget($0) }
+            // when they declare a custom widget in uiSchema — unless they belong
+            // to a non-matching conditional branch.
+            let orderedFromUi = uiOrder.filter {
+                !hidden.contains($0) && (dict.keys.contains($0) || hasCustomWidget($0))
+            }
             let remainingKeys = dict.keys.filter { !uiOrder.contains($0) }
             orderedKeys = orderedFromUi + remainingKeys
         } else if let orderMap = uiSchema?["__propertyKeyOrder"] as? [String: [String]],
             let jsonOrder = orderMap[id]
         {
-            // Use the original JSON property order, filtering to keys present in schema
-            orderedKeys = jsonOrder.filter { dict.keys.contains($0) }
+            // Use the original JSON property order, filtering to keys present in
+            // schema; conditional-branch keys are absent from the raw property
+            // order, so append them at the end.
+            let orderedFromJson = jsonOrder.filter { dict.keys.contains($0) }
+            let remainingKeys = dict.keys.filter { !jsonOrder.contains($0) }
+            orderedKeys = orderedFromJson + remainingKeys
         } else {
             orderedKeys = Array(dict.keys)
         }
@@ -59,13 +120,20 @@ struct ObjectField: Field {
         return JSONSchema.string()
     }
 
-    // Get required properties from schema
+    // Get required properties from schema, including matching conditional branches
     private var requiredProperties: [String]? {
         guard case .object = schema.type else {
             return nil
         }
 
-        return schema.objectSchema?.required
+        var required = schema.objectSchema?.required ?? []
+        for branch in activeBranchSchemas {
+            guard let branchRequired = branch["required"] as? [String] else { continue }
+            for name in branchRequired where !required.contains(name) {
+                required.append(name)
+            }
+        }
+        return required
     }
 
     /// Object template name requested by the schema's uiSchema, if any.
@@ -137,7 +205,8 @@ struct ObjectField: Field {
         return formData
     }
 
-    /// Computes the uiSchema for a child property, propagating property key order
+    /// Computes the uiSchema for a child property, propagating property key
+    /// order and object-level conditionals
     private func childUiSchema(for name: String) -> [String: Any]? {
         var result = uiSchema?[name] as? [String: Any]
         if let orderMap = uiSchema?["__propertyKeyOrder"] {
@@ -145,6 +214,12 @@ struct ObjectField: Field {
                 result = [:]
             }
             result?["__propertyKeyOrder"] = orderMap
+        }
+        if let conditionals = uiSchema?["__objectConditionals"] {
+            if result == nil {
+                result = [:]
+            }
+            result?["__objectConditionals"] = conditionals
         }
         return result
     }

--- a/Sources/JSONSchemaForm/JSONSchemaForm.swift
+++ b/Sources/JSONSchemaForm/JSONSchemaForm.swift
@@ -200,17 +200,26 @@ public struct JSONSchemaForm: View {
         self.formData = formData
         self.conditionalSchemas = conditionalSchemas
 
-        // Merge property key order into uiSchema so it flows through the view hierarchy
+        // Merge property key order and object-level if/then/else conditionals
+        // into uiSchema so they flow through the view hierarchy
+        var mergedUiSchema = uiSchema
         if let order = schemaJSON.flatMap({
             PropertyOrderExtractor.extractPropertyOrder(
                 from: $0, idPrefix: idPrefix, idSeparator: idSeparator)
         }) {
-            var mergedUiSchema = uiSchema ?? [:]
-            mergedUiSchema["__propertyKeyOrder"] = order
-            self.uiSchema = mergedUiSchema
-        } else {
-            self.uiSchema = uiSchema
+            var merged = mergedUiSchema ?? [:]
+            merged["__propertyKeyOrder"] = order
+            mergedUiSchema = merged
         }
+        if let objectConditionals = schemaJSON.flatMap({
+            ObjectConditionalExtractor.extract(
+                from: $0, idPrefix: idPrefix, idSeparator: idSeparator)
+        }) {
+            var merged = mergedUiSchema ?? [:]
+            merged["__objectConditionals"] = objectConditionals
+            mergedUiSchema = merged
+        }
+        self.uiSchema = mergedUiSchema
 
         self.onSubmit = onSubmit
         self.onError = onError

--- a/Sources/JSONSchemaForm/Utils/ObjectConditionalExtractor.swift
+++ b/Sources/JSONSchemaForm/Utils/ObjectConditionalExtractor.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// Extracts object-level `if`/`then`/`else` conditionals from a raw JSON
+/// schema string, keyed by field ID path ("root", "root_settings", ...).
+///
+/// The `JSONSchema` model type does not represent `if`/`then`/`else`, so this
+/// utility parses the raw JSON directly (the same side-channel pattern as
+/// `PropertyOrderExtractor`). The result is injected into the uiSchema under
+/// the reserved `__objectConditionals` key and consumed by `ObjectField`,
+/// which shows/hides the conditional properties as the object's own form
+/// data changes.
+enum ObjectConditionalExtractor {
+
+    /// Walks the raw schema JSON and returns per-object conditionals keyed by
+    /// field ID: any object node carrying "if" (plus optional "then"/"else")
+    /// yields a `ConditionalSchema` under that node's field ID.
+    ///
+    /// - Parameters:
+    ///   - jsonString: The raw JSON schema string
+    ///   - idPrefix: The root field ID prefix (default: "root")
+    ///   - idSeparator: The separator used in field IDs (default: "_")
+    /// - Returns: A dictionary mapping field ID paths to their conditionals,
+    ///   or `nil` when the JSON has none (or cannot be parsed).
+    static func extract(
+        from jsonString: String,
+        idPrefix: String = "root",
+        idSeparator: String = "_"
+    ) -> [String: [ConditionalSchema]]? {
+        guard let data = jsonString.data(using: .utf8),
+            let root = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+        else {
+            return nil
+        }
+        var result: [String: [ConditionalSchema]] = [:]
+        walk(schema: root, id: idPrefix, separator: idSeparator, result: &result)
+        return result.isEmpty ? nil : result
+    }
+
+    private static func walk(
+        schema: [String: Any],
+        id: String,
+        separator: String,
+        result: inout [String: [ConditionalSchema]]
+    ) {
+        if let condition = schema["if"] as? [String: Any] {
+            result[id, default: []].append(
+                ConditionalSchema(
+                    condition: condition,
+                    thenSchema: schema["then"] as? [String: Any],
+                    elseSchema: schema["else"] as? [String: Any]
+                ))
+        }
+        guard let properties = schema["properties"] as? [String: Any] else { return }
+        for (name, child) in properties {
+            if let childSchema = child as? [String: Any] {
+                walk(
+                    schema: childSchema,
+                    id: "\(id)\(separator)\(name)",
+                    separator: separator,
+                    result: &result)
+            }
+        }
+    }
+}

--- a/Sources/JSONSchemaForm/Utils/SchemaMerger.swift
+++ b/Sources/JSONSchemaForm/Utils/SchemaMerger.swift
@@ -45,7 +45,7 @@ public enum SchemaMerger {
     }
 
     /// Parse a raw property schema dictionary into a JSONSchema
-    private static func parsePropertySchema(_ propDict: [String: Any], name: String) -> JSONSchema? {
+    static func parsePropertySchema(_ propDict: [String: Any], name: String) -> JSONSchema? {
         do {
             let jsonData = try JSONSerialization.data(withJSONObject: propDict, options: [])
             let schema = try JSONDecoder().decode(JSONSchema.self, from: jsonData)

--- a/Sources/JSONSchemaFormTests/JSONSchemaForm+ObjectConditionalTests.swift
+++ b/Sources/JSONSchemaFormTests/JSONSchemaForm+ObjectConditionalTests.swift
@@ -1,0 +1,210 @@
+import JSONSchema
+import SwiftUI
+import ViewInspector
+import XCTest
+
+@testable import JSONSchemaForm
+
+/// Tests for object-level if/then/else conditionals: an object schema can
+/// declare `if`/`then`/`else` and its conditional properties show/hide based
+/// on the object's own form data, without switching the root to AllOfField
+/// (so custom widgets, templates and ui:order keep working).
+class JSONSchemaFormObjectConditionalTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        executionTimeAllowance = 30
+    }
+
+    /// Mirrors the shape of a real server-driven form: a nested "settings"
+    /// object whose "discussants" field only exists when type == "discussion".
+    private let settingsSchemaJSON = """
+        {
+            "type": "object",
+            "properties": {
+                "topic": { "type": "string" },
+                "settings": {
+                    "type": "object",
+                    "properties": {
+                        "type": { "type": "string", "enum": ["discussion", "audio-book"] },
+                        "language": { "type": "string" }
+                    },
+                    "required": ["type", "language"],
+                    "if": {
+                        "properties": { "type": { "const": "discussion" } },
+                        "required": ["type"]
+                    },
+                    "then": {
+                        "properties": {
+                            "discussants": { "type": "integer", "minimum": 2, "maximum": 6, "default": 3 }
+                        },
+                        "required": ["discussants"]
+                    }
+                }
+            }
+        }
+        """
+
+    private func formData(type: String) -> FormData {
+        FormData.object(properties: [
+            "topic": .string("hello"),
+            "settings": .object(properties: [
+                "type": .string(type),
+                "language": .string("en-US"),
+                "discussants": .number(3),
+            ]),
+        ])
+    }
+
+    // MARK: - Extractor unit tests
+
+    @MainActor
+    func testExtractorFindsNestedConditionals() async throws {
+        let result = ObjectConditionalExtractor.extract(from: settingsSchemaJSON)
+        XCTAssertNotNil(result, "Extractor should find the settings conditional")
+        let conditionals = result?["root_settings"] ?? []
+        XCTAssertEqual(conditionals.count, 1, "settings should carry exactly one conditional")
+        XCTAssertNotNil(conditionals[0].thenSchema, "then schema should be captured")
+        XCTAssertNil(conditionals[0].elseSchema, "no else schema declared")
+        XCTAssertNil(result?["root"], "root object declares no conditional")
+    }
+
+    @MainActor
+    func testExtractorReturnsNilWithoutConditionals() async throws {
+        let plain = """
+            { "type": "object", "properties": { "name": { "type": "string" } } }
+            """
+        XCTAssertNil(ObjectConditionalExtractor.extract(from: plain))
+    }
+
+    @MainActor
+    func testExtractorCapturesElseBranch() async throws {
+        let withElse = """
+            {
+                "type": "object",
+                "properties": { "kind": { "type": "string" } },
+                "if": { "properties": { "kind": { "const": "a" } } },
+                "then": { "properties": { "fieldA": { "type": "string" } } },
+                "else": { "properties": { "fieldB": { "type": "string" } } }
+            }
+            """
+        let result = ObjectConditionalExtractor.extract(from: withElse)
+        let conditionals = result?["root"] ?? []
+        XCTAssertEqual(conditionals.count, 1)
+        XCTAssertNotNil(conditionals[0].thenSchema)
+        XCTAssertNotNil(conditionals[0].elseSchema)
+    }
+
+    // MARK: - Rendering
+
+    @MainActor
+    func testConditionalFieldVisibleWhenConditionMatches() async throws {
+        let schema = try JSONSchema(jsonString: settingsSchemaJSON)
+        let data = Binding(wrappedValue: formData(type: "discussion"))
+        let form = JSONSchemaForm(
+            schema: schema, formData: data, schemaJSON: settingsSchemaJSON)
+
+        let view = try form.inspect()
+        XCTAssertNoThrow(
+            try view.find(viewWithId: "root_settings_discussants"),
+            "discussants should render for type=discussion")
+        XCTAssertNoThrow(try view.find(viewWithId: "root_settings_type"))
+        XCTAssertNoThrow(try view.find(viewWithId: "root_settings_language"))
+    }
+
+    @MainActor
+    func testConditionalFieldHiddenWhenConditionFails() async throws {
+        let schema = try JSONSchema(jsonString: settingsSchemaJSON)
+        let data = Binding(wrappedValue: formData(type: "audio-book"))
+        let form = JSONSchemaForm(
+            schema: schema, formData: data, schemaJSON: settingsSchemaJSON)
+
+        let view = try form.inspect()
+        XCTAssertThrowsError(
+            try view.find(viewWithId: "root_settings_discussants"),
+            "discussants should be hidden for type=audio-book")
+        // Base fields keep rendering.
+        XCTAssertNoThrow(try view.find(viewWithId: "root_settings_type"))
+        XCTAssertNoThrow(try view.find(viewWithId: "root_settings_language"))
+        // The hidden field's value is intentionally left in formData so it
+        // restores when the condition flips back.
+        let settings = data.wrappedValue.object?["settings"]?.object
+        XCTAssertEqual(settings?["discussants"], .number(3))
+    }
+
+    @MainActor
+    func testConditionalHiddenEvenWithCustomWidgetInUiOrder() async throws {
+        let schema = try JSONSchema(jsonString: settingsSchemaJSON)
+        let uiSchema: [String: Any] = [
+            "settings": [
+                "ui:order": ["type", "discussants", "language"],
+                "discussants": ["ui:widget": "stepper"],
+            ]
+        ]
+        let widgets: [String: JSONSchemaFormWidget] = [
+            "stepper": { _ in AnyView(Text("Panelists Row").id("panelists_widget")) }
+        ]
+
+        // Hidden: the ui:order + custom-widget fallback must not resurrect it.
+        let hiddenData = Binding(wrappedValue: formData(type: "audio-book"))
+        let hiddenForm = JSONSchemaForm(
+            schema: schema, uiSchema: uiSchema, formData: hiddenData,
+            schemaJSON: settingsSchemaJSON, widgets: widgets)
+        XCTAssertThrowsError(
+            try hiddenForm.inspect().find(viewWithId: "panelists_widget"),
+            "custom widget must not render while the conditional hides the key")
+
+        // Visible: same setup, matching condition.
+        let visibleData = Binding(wrappedValue: formData(type: "discussion"))
+        let visibleForm = JSONSchemaForm(
+            schema: schema, uiSchema: uiSchema, formData: visibleData,
+            schemaJSON: settingsSchemaJSON, widgets: widgets)
+        XCTAssertNoThrow(
+            try visibleForm.inspect().find(viewWithId: "panelists_widget"),
+            "custom widget should render when the condition matches")
+    }
+
+    @MainActor
+    func testElseBranchRendersWhenConditionFails() async throws {
+        let schemaJSON = """
+            {
+                "type": "object",
+                "properties": { "kind": { "type": "string" } },
+                "if": { "properties": { "kind": { "const": "a" } } },
+                "then": { "properties": { "fieldA": { "type": "string" } } },
+                "else": { "properties": { "fieldB": { "type": "string" } } }
+            }
+            """
+        let schema = try JSONSchema(jsonString: schemaJSON)
+
+        let dataA = Binding(
+            wrappedValue: FormData.object(properties: ["kind": .string("a")]))
+        let formA = JSONSchemaForm(schema: schema, formData: dataA, schemaJSON: schemaJSON)
+        let viewA = try formA.inspect()
+        XCTAssertNoThrow(try viewA.find(viewWithId: "root_fieldA"))
+        XCTAssertThrowsError(try viewA.find(viewWithId: "root_fieldB"))
+
+        let dataB = Binding(
+            wrappedValue: FormData.object(properties: ["kind": .string("b")]))
+        let formB = JSONSchemaForm(schema: schema, formData: dataB, schemaJSON: schemaJSON)
+        let viewB = try formB.inspect()
+        XCTAssertThrowsError(try viewB.find(viewWithId: "root_fieldA"))
+        XCTAssertNoThrow(try viewB.find(viewWithId: "root_fieldB"))
+    }
+
+    @MainActor
+    func testConditionFlipRestoresField() async throws {
+        let schema = try JSONSchema(jsonString: settingsSchemaJSON)
+        var data = formData(type: "audio-book")
+        let binding = Binding(get: { data }, set: { data = $0 })
+
+        var form = JSONSchemaForm(schema: schema, formData: binding, schemaJSON: settingsSchemaJSON)
+        XCTAssertThrowsError(try form.inspect().find(viewWithId: "root_settings_discussants"))
+
+        // Flip the type back to discussion: the field (and its retained value)
+        // must come back.
+        data = formData(type: "discussion")
+        form = JSONSchemaForm(schema: schema, formData: binding, schemaJSON: settingsSchemaJSON)
+        XCTAssertNoThrow(try form.inspect().find(viewWithId: "root_settings_discussants"))
+        XCTAssertEqual(data.object?["settings"]?.object?["discussants"], .number(3))
+    }
+}


### PR DESCRIPTION
Object schemas can now declare standard JSON Schema if/then/else and have their conditional properties show/hide based on the object's own form data. Conditionals are extracted from the raw schemaJSON at init (the JSONSchema model does not represent if/then/else) and delivered to ObjectField through the uiSchema side-channel (__objectConditionals), so custom widgets, object templates and ui:order keep working — unlike the root-level AllOfField path.

Hidden conditional keys are also excluded from the ui:order custom-widget fallback, and their values are intentionally kept in formData so a field restores its value when the condition flips back.

Out of scope: JSONSchemaValidator does not evaluate then/else required constraints.