### PR TITLE
feat: built-in foreign-key field with searchable paginated picker

### DIFF
--- a/Sources/JSONSchemaForm/Fields/ForeignKeyField.swift
+++ b/Sources/JSONSchemaForm/Fields/ForeignKeyField.swift
@@ -1,0 +1,128 @@
+import JSONSchema
+import SwiftUI
+
+/// Renders a foreign-key field (`ui:widget: "foreign-key"`) as a row that
+/// pushes a dedicated searchable, paginated picker page.
+///
+/// The field is configuration-driven: the schema's `ui:options.endpoint`
+/// names the record collection, while the app-injected
+/// `ForeignKeyConfiguration` (via `JSONSchemaForm(foreignKey:)`) supplies the
+/// authenticated search client and the transform that converts a picked item
+/// into stored FormData. Without a configuration or endpoint the field falls
+/// back to a plain string input so schemas stay editable.
+struct ForeignKeyField: Field {
+    static let widgetName = "foreign-key"
+
+    var schema: JSONSchema
+    var uiSchema: [String: Any]?
+    var id: String
+    var formData: Binding<FormData>
+    var required: Bool
+    var propertyName: String?
+    /// App-supplied configuration, threaded down from
+    /// `JSONSchemaForm(foreignKey:)` alongside `widgets`.
+    var configuration: ForeignKeyConfiguration?
+
+    /// Title of the item picked in this session, shown without a resolve
+    /// round-trip.
+    @State private var pickedTitle: String?
+    /// Title resolved from the stored id via the client.
+    @State private var resolvedTitle: String?
+
+    private var uiOptions: [String: Any]? {
+        getUiOptions(uiSchema: uiSchema, globalUiOptions: nil)
+    }
+
+    private var endpoint: String? {
+        uiOptions?["endpoint"] as? String
+    }
+
+    private var searchable: Bool {
+        uiOptions?["searchable"] as? Bool ?? true
+    }
+
+    private var accessibilityID: String {
+        uiOptions?["accessibility_id"] as? String ?? id
+    }
+
+    private var rowTitle: String {
+        fieldTitle.isEmpty ? (propertyName ?? "") : fieldTitle
+    }
+
+    var body: some View {
+        if let configuration, let endpoint {
+            selectionRow(configuration: configuration, endpoint: endpoint)
+        } else {
+            // No app configuration (or no endpoint in ui:options) — degrade
+            // to the plain string input so the value stays editable.
+            StringField(
+                schema: schema,
+                uiSchema: uiSchema,
+                id: id,
+                formData: formData,
+                required: required,
+                propertyName: propertyName
+            )
+        }
+    }
+
+    private func selectionRow(
+        configuration: ForeignKeyConfiguration, endpoint: String
+    ) -> some View {
+        let context = ForeignKeyFieldContext(
+            id: id,
+            propertyName: propertyName,
+            endpoint: endpoint,
+            schema: schema,
+            uiOptions: uiOptions
+        )
+        let storedID = configuration.storedID(formData.wrappedValue)
+
+        return NavigationLink {
+            ForeignKeyPickerView(
+                title: rowTitle,
+                configuration: configuration,
+                context: context,
+                searchable: searchable,
+                required: required,
+                formData: formData,
+                onPicked: { item in
+                    pickedTitle = item?.title
+                    resolvedTitle = nil
+                }
+            )
+        } label: {
+            HStack {
+                Text(rowTitle)
+                    .foregroundStyle(.primary)
+                Spacer()
+                Text(displayValue(storedID: storedID))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+        }
+        .id("\(id)_foreignkey")
+        .accessibilityIdentifier(accessibilityID)
+        .task(id: storedID) {
+            await resolveTitleIfNeeded(
+                configuration: configuration, endpoint: endpoint, storedID: storedID)
+        }
+    }
+
+    private func displayValue(storedID: String?) -> String {
+        guard storedID != nil else { return "None" }
+        return pickedTitle ?? resolvedTitle ?? storedID ?? "None"
+    }
+
+    /// Resolves the stored id to a human-readable title through the client.
+    /// Skipped when the title is already known from an in-session pick.
+    private func resolveTitleIfNeeded(
+        configuration: ForeignKeyConfiguration, endpoint: String, storedID: String?
+    ) async {
+        guard pickedTitle == nil, resolvedTitle == nil, let storedID else { return }
+        guard
+            let item = try? await configuration.client.resolve(endpoint: endpoint, id: storedID)
+        else { return }
+        resolvedTitle = item.title
+    }
+}

--- a/Sources/JSONSchemaForm/Fields/ObjectField.swift
+++ b/Sources/JSONSchemaForm/Fields/ObjectField.swift
@@ -11,6 +11,7 @@ struct ObjectField: Field {
     var required: Bool
     var propertyName: String?
     var widgets: [String: JSONSchemaFormWidget] = [:]
+    var foreignKey: ForeignKeyConfiguration?
 
     @Environment(\.formTemplates) private var templates
 
@@ -112,7 +113,7 @@ struct ObjectField: Field {
               let widgetName = propertyUiSchema["ui:widget"] as? String else {
             return false
         }
-        return widgets[widgetName] != nil
+        return widgets[widgetName] != nil || widgetName == ForeignKeyField.widgetName
     }
 
     private func virtualSchema(for name: String) -> JSONSchema? {
@@ -245,7 +246,8 @@ struct ObjectField: Field {
                 formData: schemaBinding(name: name),
                 required: isRequired,
                 propertyName: name,
-                widgets: widgets
+                widgets: widgets,
+                foreignKey: foreignKey
             )
         } else {
             InvalidValueType(

--- a/Sources/JSONSchemaForm/Fields/SchemaField.swift
+++ b/Sources/JSONSchemaForm/Fields/SchemaField.swift
@@ -17,6 +17,9 @@ struct SchemaField: Field {
     /// Custom widgets keyed by `ui:widget`.
     var widgets: [String: JSONSchemaFormWidget]
 
+    /// App-supplied configuration for built-in `foreign-key` fields.
+    var foreignKey: ForeignKeyConfiguration?
+
     /// Access to the form controller for field-level error display
     @Environment(\.formController) private var formController
 
@@ -40,7 +43,8 @@ struct SchemaField: Field {
     init(
         schema: JSONSchema, uiSchema: [String: Any]?, id: String, formData: Binding<FormData>,
         required: Bool, propertyName: String? = nil, conditionalSchemas: [ConditionalSchema]? = nil,
-        widgets: [String: JSONSchemaFormWidget] = [:]
+        widgets: [String: JSONSchemaFormWidget] = [:],
+        foreignKey: ForeignKeyConfiguration? = nil
     ) {
         self.schema = schema
         self.uiSchema = uiSchema
@@ -50,6 +54,7 @@ struct SchemaField: Field {
         self.propertyName = propertyName
         self.conditionalSchemas = conditionalSchemas
         self.widgets = widgets
+        self.foreignKey = foreignKey
     }
 
     /// The non-null branch when this anyOf schema is just a nullable wrapper
@@ -95,6 +100,28 @@ struct SchemaField: Field {
                     formData: schemaDataBinding(schemaType: schema.type),
                     required: required
                 ))
+            } else if uiWidget == ForeignKeyField.widgetName {
+                // Built-in foreign-key field: a row pushing a dedicated
+                // searchable, paginated picker page. An app-registered
+                // widget of the same name (above) still takes precedence.
+                TemplatedField(
+                    id: id,
+                    label: fieldTitle,
+                    description: schema.description,
+                    errors: currentFieldErrors,
+                    required: required,
+                    uiSchema: uiSchema
+                ) {
+                    ForeignKeyField(
+                        schema: schema,
+                        uiSchema: uiSchema,
+                        id: id,
+                        formData: schemaDataBinding(schemaType: schema.type),
+                        required: required,
+                        propertyName: propertyName,
+                        configuration: foreignKey
+                    )
+                }
             } else if let customField = uiField {
                 // If a custom field is specified in uiSchema, use it
                 // In a complete implementation, this would look up the custom field
@@ -207,7 +234,8 @@ struct SchemaField: Field {
                     formData: schemaDataBinding(schemaType: schema.type),
                     required: required,
                     propertyName: propertyName,
-                    widgets: widgets
+                    widgets: widgets,
+                    foreignKey: foreignKey
                 )
             }
 
@@ -277,7 +305,8 @@ struct SchemaField: Field {
                     formData: formData,
                     required: false,
                     propertyName: propertyName,
-                    widgets: widgets
+                    widgets: widgets,
+                    foreignKey: foreignKey
                 )
             } else {
                 // AnyOf fields use OneOfField with their own layout

--- a/Sources/JSONSchemaForm/ForeignKey/ForeignKey.swift
+++ b/Sources/JSONSchemaForm/ForeignKey/ForeignKey.swift
@@ -1,0 +1,95 @@
+import JSONSchema
+import SwiftUI
+
+// MARK: - Foreign Key Types
+
+/// One selectable record returned by the app's search client.
+public struct ForeignKeyItem: Identifiable, Equatable, Sendable {
+    public let id: String
+    public let title: String
+    public let subtitle: String?
+    /// Full record payload, for transforms that store the whole object
+    /// rather than just the id.
+    public let raw: FormData?
+
+    public init(id: String, title: String, subtitle: String? = nil, raw: FormData? = nil) {
+        self.id = id
+        self.title = title
+        self.subtitle = subtitle
+        self.raw = raw
+    }
+}
+
+/// One page of search results with an opaque cursor for the next page.
+public struct ForeignKeyPage: Sendable {
+    public let items: [ForeignKeyItem]
+    public let nextCursor: String?
+
+    public init(items: [ForeignKeyItem], nextCursor: String? = nil) {
+        self.items = items
+        self.nextCursor = nextCursor
+    }
+}
+
+/// Implemented by the host app. The library never talks to the network
+/// itself — the client owns URL construction, authentication, and response
+/// parsing, so requests carry the app's credentials.
+@MainActor
+public protocol ForeignKeySearchClient: AnyObject, Sendable {
+    /// Fetch one page of records for `endpoint` (the opaque token from the
+    /// field's `ui:options.endpoint`), optionally filtered by `query` and
+    /// starting at `cursor`.
+    func search(endpoint: String, query: String?, cursor: String?) async throws -> ForeignKeyPage
+
+    /// Resolve an already-stored id to a display item so the field row can
+    /// show a human-readable title. Optional — the default returns nil and
+    /// the raw id is shown instead.
+    func resolve(endpoint: String, id: String) async throws -> ForeignKeyItem?
+}
+
+public extension ForeignKeySearchClient {
+    func resolve(endpoint: String, id: String) async throws -> ForeignKeyItem? { nil }
+}
+
+/// Field context handed to the transform so a single closure can vary its
+/// behavior per field.
+public struct ForeignKeyFieldContext {
+    public let id: String
+    public let propertyName: String?
+    public let endpoint: String
+    public let schema: JSONSchema
+    public let uiOptions: [String: Any]?
+}
+
+public typealias ForeignKeyTransform =
+    @MainActor @Sendable (ForeignKeyItem, ForeignKeyFieldContext) -> FormData
+public typealias ForeignKeyStoredID = @MainActor @Sendable (FormData) -> String?
+
+/// Configuration for fields marked `ui:widget: "foreign-key"`. Pass it to
+/// `JSONSchemaForm(foreignKey:)`; without it those fields fall back to a
+/// plain string input.
+public struct ForeignKeyConfiguration: Sendable {
+    /// App-owned client performing (authenticated) search requests.
+    public let client: any ForeignKeySearchClient
+    /// Converts a picked item into the stored FormData. Some APIs store just
+    /// the id, others the full object. Default stores `.string(item.id)`.
+    public let transform: ForeignKeyTransform
+    /// Extracts the stored id back out of FormData, used to resolve the
+    /// current selection's title and to highlight it in the picker. Default
+    /// unwraps `.string`; apps that store full objects supply their own.
+    public let storedID: ForeignKeyStoredID
+
+    public init(
+        client: any ForeignKeySearchClient,
+        transform: @escaping ForeignKeyTransform = { item, _ in .string(item.id) },
+        storedID: @escaping ForeignKeyStoredID = { value in
+            if case .string(let id) = value, !id.isEmpty { return id }
+            return nil
+        }
+    ) {
+        self.client = client
+        self.transform = transform
+        self.storedID = storedID
+    }
+}
+

--- a/Sources/JSONSchemaForm/ForeignKey/ForeignKeyPickerModel.swift
+++ b/Sources/JSONSchemaForm/ForeignKey/ForeignKeyPickerModel.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Observation
+
+/// Search + cursor-pagination state for the foreign-key picker page.
+///
+/// A monotonically increasing generation counter guards against stale
+/// responses: any load that started before the latest reset (new search,
+/// pull-to-refresh) is dropped when it lands.
+@MainActor
+@Observable
+final class ForeignKeyPickerModel {
+    let client: any ForeignKeySearchClient
+    let endpoint: String
+    let searchable: Bool
+
+    var items: [ForeignKeyItem] = []
+    var query = ""
+    var nextCursor: String?
+    var isLoading = false
+    /// True once the first page request has completed (successfully or not),
+    /// so the view can distinguish "loading" from "genuinely empty".
+    var hasLoaded = false
+    var errorMessage: String?
+    private var requestGeneration = 0
+
+    init(client: any ForeignKeySearchClient, endpoint: String, searchable: Bool) {
+        self.client = client
+        self.endpoint = endpoint
+        self.searchable = searchable
+    }
+
+    func load(reset: Bool = true) async {
+        let requestedCursor: String?
+        if reset {
+            requestGeneration &+= 1
+            requestedCursor = nil
+        } else {
+            guard !isLoading, let nextCursor else { return }
+            requestedCursor = nextCursor
+        }
+
+        let generation = requestGeneration
+        let requestedQuery = effectiveQuery
+        isLoading = true
+        defer {
+            if generation == requestGeneration {
+                isLoading = false
+            }
+        }
+
+        do {
+            let page = try await client.search(
+                endpoint: endpoint, query: requestedQuery, cursor: requestedCursor
+            )
+            guard !Task.isCancelled,
+                  generation == requestGeneration,
+                  requestedQuery == effectiveQuery
+            else { return }
+            items = reset ? page.items : items + page.items
+            nextCursor = page.nextCursor
+            errorMessage = nil
+            hasLoaded = true
+        } catch is CancellationError {
+            return
+        } catch {
+            guard generation == requestGeneration, requestedQuery == effectiveQuery else { return }
+            errorMessage = error.localizedDescription
+            hasLoaded = true
+        }
+    }
+
+    /// Triggers the next page load when `item` is the last loaded row.
+    func loadNextIfNeeded(item: ForeignKeyItem) async {
+        guard item.id == items.last?.id, nextCursor != nil else { return }
+        await load(reset: false)
+    }
+
+    private var effectiveQuery: String? {
+        guard searchable else { return nil }
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/Sources/JSONSchemaForm/ForeignKey/ForeignKeyPickerView.swift
+++ b/Sources/JSONSchemaForm/ForeignKey/ForeignKeyPickerView.swift
@@ -1,0 +1,181 @@
+import JSONSchema
+import SwiftUI
+
+/// Dedicated foreign-key picker page, pushed from `ForeignKeyField`.
+///
+/// Shows a searchable (when the field's `ui:options.searchable` is not
+/// false), lazily paginated list of records fetched through the app's
+/// `ForeignKeySearchClient`. Selecting a row runs the configuration's
+/// transform, writes the result into the form data, and pops back.
+struct ForeignKeyPickerView: View {
+    let title: String
+    let configuration: ForeignKeyConfiguration
+    let context: ForeignKeyFieldContext
+    let searchable: Bool
+    let required: Bool
+    var formData: Binding<FormData>
+    /// Reports the picked item (nil when cleared) so the field row can show
+    /// the new title without a resolve round-trip.
+    let onPicked: (ForeignKeyItem?) -> Void
+
+    @State private var model: ForeignKeyPickerModel
+    @Environment(\.dismiss) private var dismiss
+
+    /// `model` is injectable for tests; production callers let the view
+    /// create its own.
+    init(
+        title: String,
+        configuration: ForeignKeyConfiguration,
+        context: ForeignKeyFieldContext,
+        searchable: Bool,
+        required: Bool,
+        formData: Binding<FormData>,
+        onPicked: @escaping (ForeignKeyItem?) -> Void,
+        model: ForeignKeyPickerModel? = nil
+    ) {
+        self.title = title
+        self.configuration = configuration
+        self.context = context
+        self.searchable = searchable
+        self.required = required
+        self.formData = formData
+        self.onPicked = onPicked
+        _model = State(
+            initialValue: model
+                ?? ForeignKeyPickerModel(
+                    client: configuration.client,
+                    endpoint: context.endpoint,
+                    searchable: searchable
+                ))
+    }
+
+    private var storedID: String? {
+        configuration.storedID(formData.wrappedValue)
+    }
+
+    var body: some View {
+        list
+            .navigationTitle(title)
+            #if os(iOS)
+                .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .modifier(SearchableIfNeeded(searchable: searchable, query: $model.query))
+            .task(id: model.query) {
+                if model.hasLoaded {
+                    // Debounce keystrokes: `.task(id:)` cancels the previous
+                    // task on every query change, so the sleep only survives
+                    // once typing pauses.
+                    try? await Task.sleep(for: .milliseconds(300))
+                    guard !Task.isCancelled else { return }
+                }
+                await model.load(reset: true)
+            }
+            .overlay { stateOverlay }
+    }
+
+    private var list: some View {
+        List {
+            if !required, model.hasLoaded {
+                Button {
+                    select(nil)
+                } label: {
+                    HStack {
+                        Text("None")
+                            .foregroundStyle(.secondary)
+                        Spacer()
+                        if storedID == nil {
+                            Image(systemName: "checkmark")
+                                .foregroundStyle(.tint)
+                        }
+                    }
+                }
+                .accessibilityIdentifier("\(context.id)_foreignkey_none")
+            }
+
+            ForEach(model.items) { item in
+                Button {
+                    select(item)
+                } label: {
+                    HStack {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(item.title)
+                                .foregroundStyle(.primary)
+                            if let subtitle = item.subtitle, !subtitle.isEmpty {
+                                Text(subtitle)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        Spacer()
+                        if item.id == storedID {
+                            Image(systemName: "checkmark")
+                                .foregroundStyle(.tint)
+                        }
+                    }
+                }
+                .onAppear {
+                    Task { await model.loadNextIfNeeded(item: item) }
+                }
+            }
+
+            if model.isLoading, !model.items.isEmpty {
+                HStack {
+                    Spacer()
+                    ProgressView()
+                    Spacer()
+                }
+            }
+        }
+        .accessibilityIdentifier("\(context.id)_foreignkey_picker")
+    }
+
+    @ViewBuilder
+    private var stateOverlay: some View {
+        if !model.hasLoaded {
+            ProgressView()
+        } else if let errorMessage = model.errorMessage, model.items.isEmpty {
+            ContentUnavailableView {
+                Label("Couldn't Load", systemImage: "exclamationmark.triangle")
+            } description: {
+                Text(errorMessage)
+            } actions: {
+                Button("Retry") {
+                    Task { await model.load(reset: true) }
+                }
+            }
+        } else if model.items.isEmpty {
+            ContentUnavailableView(
+                "No Results",
+                systemImage: "magnifyingglass",
+                description: Text(
+                    model.query.isEmpty
+                        ? "No records available." : "No records match \"\(model.query)\".")
+            )
+        }
+    }
+
+    private func select(_ item: ForeignKeyItem?) {
+        if let item {
+            formData.wrappedValue = configuration.transform(item, context)
+        } else {
+            formData.wrappedValue = .null
+        }
+        onPicked(item)
+        dismiss()
+    }
+}
+
+/// Applies `.searchable` only when the field is searchable, so
+/// non-searchable endpoints get a plain list.
+private struct SearchableIfNeeded: ViewModifier {
+    let searchable: Bool
+    @Binding var query: String
+
+    func body(content: Content) -> some View {
+        if searchable {
+            content.searchable(text: $query, prompt: "Search")
+        } else {
+            content
+        }
+    }
+}

--- a/Sources/JSONSchemaForm/JSONSchemaForm.swift
+++ b/Sources/JSONSchemaForm/JSONSchemaForm.swift
@@ -127,6 +127,10 @@ public struct JSONSchemaForm: View {
     /// `ui:objectTemplate` / `ui:fieldTemplate` names, with optional defaults.
     var templates: JSONSchemaFormTemplates
 
+    /// Configuration for `ui:widget: "foreign-key"` fields: the app's
+    /// authenticated search client plus the selected-item transform.
+    var foreignKey: ForeignKeyConfiguration?
+
     /// String prefix for field IDs
     var idPrefix: String = "root"
 
@@ -171,6 +175,9 @@ public struct JSONSchemaForm: View {
     ///   - readonly: Whether the form is read-only (default: false)
     ///   - customValidate: Additional custom validation function
     ///   - widgets: Custom widgets keyed by `ui:widget`
+    ///   - foreignKey: Configuration for `ui:widget: "foreign-key"` fields
+    ///     (search client + selected-item transform). Without it those
+    ///     fields fall back to plain string inputs.
     ///   - idPrefix: Prefix for field IDs (default: "root")
     ///   - idSeparator: Separator for field IDs (default: "_")
     ///   - controller: Optional controller for programmatic form control
@@ -192,6 +199,7 @@ public struct JSONSchemaForm: View {
         customValidate: ((Any?, inout [String: Any]) -> Void)? = nil,
         widgets: [String: JSONSchemaFormWidget] = [:],
         templates: JSONSchemaFormTemplates = JSONSchemaFormTemplates(),
+        foreignKey: ForeignKeyConfiguration? = nil,
         idPrefix: String = "root",
         idSeparator: String = "_",
         controller: JSONSchemaFormController? = nil
@@ -233,6 +241,7 @@ public struct JSONSchemaForm: View {
         self.customValidate = customValidate
         self.widgets = widgets
         self.templates = templates
+        self.foreignKey = foreignKey
         self.idPrefix = idPrefix
         self.idSeparator = idSeparator
         self.externalController = controller
@@ -253,7 +262,8 @@ public struct JSONSchemaForm: View {
                 formData: formData,
                 required: false,
                 conditionalSchemas: conditionalSchemas,
-                widgets: widgets
+                widgets: widgets,
+                foreignKey: foreignKey
             )
 
             if showSubmitButton {

--- a/Sources/JSONSchemaFormTests/ForeignKeyPickerModelTests.swift
+++ b/Sources/JSONSchemaFormTests/ForeignKeyPickerModelTests.swift
@@ -1,0 +1,207 @@
+import JSONSchema
+import XCTest
+
+@testable import JSONSchemaForm
+
+/// Mock search client with scripted pages (by request index) and request
+/// recording. The first request can be gated so tests can interleave
+/// overlapping loads deterministically.
+@MainActor
+private final class MockSearchClient: ForeignKeySearchClient {
+    struct Request: Equatable {
+        let endpoint: String
+        let query: String?
+        let cursor: String?
+    }
+
+    var pages: [ForeignKeyPage] = []
+    var error: Error?
+    var requests: [Request] = []
+
+    /// When true, the first search suspends until `releaseGate()` is called.
+    var gateFirstSearch = false
+    private var gateContinuation: CheckedContinuation<Void, Never>?
+
+    func releaseGate() {
+        gateContinuation?.resume()
+        gateContinuation = nil
+    }
+
+    func search(endpoint: String, query: String?, cursor: String?) async throws -> ForeignKeyPage {
+        let index = requests.count
+        requests.append(Request(endpoint: endpoint, query: query, cursor: cursor))
+        if index == 0, gateFirstSearch {
+            await withCheckedContinuation { gateContinuation = $0 }
+        }
+        if let error { throw error }
+        guard index < pages.count else { return ForeignKeyPage(items: [], nextCursor: nil) }
+        return pages[index]
+    }
+
+    var resolveResult: ForeignKeyItem?
+    func resolve(endpoint: String, id: String) async throws -> ForeignKeyItem? {
+        resolveResult
+    }
+}
+
+private func item(_ id: String) -> ForeignKeyItem {
+    ForeignKeyItem(id: id, title: "Title \(id)")
+}
+
+final class ForeignKeyPickerModelTests: XCTestCase {
+
+    @MainActor
+    func testFirstLoadPopulatesItemsAndCursor() async {
+        let client = MockSearchClient()
+        client.pages = [ForeignKeyPage(items: [item("1"), item("2")], nextCursor: "c1")]
+        let model = ForeignKeyPickerModel(client: client, endpoint: "stations", searchable: true)
+
+        await model.load(reset: true)
+
+        XCTAssertEqual(model.items.map(\.id), ["1", "2"])
+        XCTAssertEqual(model.nextCursor, "c1")
+        XCTAssertTrue(model.hasLoaded)
+        XCTAssertNil(model.errorMessage)
+        XCTAssertEqual(client.requests, [.init(endpoint: "stations", query: nil, cursor: nil)])
+    }
+
+    @MainActor
+    func testSearchQueryIsTrimmedAndPassedOnlyWhenSearchable() async {
+        let client = MockSearchClient()
+        let model = ForeignKeyPickerModel(client: client, endpoint: "stations", searchable: true)
+        model.query = "  tokyo  "
+        await model.load(reset: true)
+        XCTAssertEqual(client.requests.last?.query, "tokyo")
+
+        let unsearchable = ForeignKeyPickerModel(
+            client: client, endpoint: "platforms", searchable: false)
+        unsearchable.query = "ignored"
+        await unsearchable.load(reset: true)
+        XCTAssertNil(client.requests.last?.query)
+    }
+
+    @MainActor
+    func testLoadMoreAppendsUsingCursor() async {
+        let client = MockSearchClient()
+        client.pages = [
+            ForeignKeyPage(items: [item("1")], nextCursor: "c1"),
+            ForeignKeyPage(items: [item("2")], nextCursor: nil),
+        ]
+        let model = ForeignKeyPickerModel(client: client, endpoint: "stations", searchable: true)
+
+        await model.load(reset: true)
+        await model.load(reset: false)
+
+        XCTAssertEqual(model.items.map(\.id), ["1", "2"])
+        XCTAssertNil(model.nextCursor)
+        XCTAssertEqual(client.requests.last, .init(endpoint: "stations", query: nil, cursor: "c1"))
+    }
+
+    @MainActor
+    func testLoadNextIfNeededOnlyFiresOnLastItemWithCursor() async {
+        let client = MockSearchClient()
+        client.pages = [
+            ForeignKeyPage(items: [item("1"), item("2")], nextCursor: "c1"),
+            ForeignKeyPage(items: [item("3")], nextCursor: nil),
+        ]
+        let model = ForeignKeyPickerModel(client: client, endpoint: "stations", searchable: true)
+        await model.load(reset: true)
+
+        // Not the last item — no request.
+        await model.loadNextIfNeeded(item: item("1"))
+        XCTAssertEqual(client.requests.count, 1)
+
+        // Last item with a cursor — loads the next page.
+        await model.loadNextIfNeeded(item: item("2"))
+        XCTAssertEqual(model.items.map(\.id), ["1", "2", "3"])
+
+        // Cursor exhausted — no request.
+        await model.loadNextIfNeeded(item: item("3"))
+        XCTAssertEqual(client.requests.count, 2)
+    }
+
+    @MainActor
+    func testResetDropsStaleInFlightResults() async {
+        let client = MockSearchClient()
+        client.pages = [
+            ForeignKeyPage(items: [item("stale")], nextCursor: "stale-cursor"),
+            ForeignKeyPage(items: [item("fresh")], nextCursor: nil),
+        ]
+        client.gateFirstSearch = true
+        let model = ForeignKeyPickerModel(client: client, endpoint: "stations", searchable: true)
+
+        // First load suspends inside the client; a second reset load starts
+        // and finishes while the first is still in flight.
+        let first = Task { await model.load(reset: true) }
+        while client.requests.count < 1 { await Task.yield() }
+        await model.load(reset: true)
+        XCTAssertEqual(model.items.map(\.id), ["fresh"])
+
+        // Release the first request: its (stale-generation) result must be dropped.
+        client.releaseGate()
+        await first.value
+        XCTAssertEqual(model.items.map(\.id), ["fresh"])
+        XCTAssertNil(model.nextCursor)
+        XCTAssertFalse(model.isLoading)
+    }
+
+    @MainActor
+    func testErrorSurfacesMessageAndMarksLoaded() async {
+        let client = MockSearchClient()
+        client.error = NSError(
+            domain: "test", code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "network down"])
+        let model = ForeignKeyPickerModel(client: client, endpoint: "stations", searchable: true)
+
+        await model.load(reset: true)
+
+        XCTAssertEqual(model.errorMessage, "network down")
+        XCTAssertTrue(model.hasLoaded)
+        XCTAssertTrue(model.items.isEmpty)
+    }
+
+    // MARK: - Configuration defaults
+
+    @MainActor
+    func testDefaultTransformStoresID() async throws {
+        let client = MockSearchClient()
+        let configuration = ForeignKeyConfiguration(client: client)
+        let schema = try JSONSchema(jsonString: #"{"type": "string"}"#)
+        let context = ForeignKeyFieldContext(
+            id: "root_stationId", propertyName: "stationId",
+            endpoint: "stations", schema: schema, uiOptions: nil)
+
+        let stored = configuration.transform(item("s1"), context)
+
+        XCTAssertEqual(stored, .string("s1"))
+        XCTAssertEqual(configuration.storedID(stored), "s1")
+        XCTAssertNil(configuration.storedID(.string("")))
+        XCTAssertNil(configuration.storedID(.null))
+    }
+
+    @MainActor
+    func testCustomObjectTransformRoundTrips() async throws {
+        let client = MockSearchClient()
+        let configuration = ForeignKeyConfiguration(
+            client: client,
+            transform: { item, _ in
+                item.raw ?? .object(properties: ["id": .string(item.id)])
+            },
+            storedID: { value in
+                value.object?["id"]?.string
+            }
+        )
+        let schema = try JSONSchema(jsonString: #"{"type": "object"}"#)
+        let context = ForeignKeyFieldContext(
+            id: "root_station", propertyName: "station",
+            endpoint: "stations", schema: schema, uiOptions: nil)
+        let record = ForeignKeyItem(
+            id: "s1", title: "Tokyo",
+            raw: .object(properties: ["id": .string("s1"), "name": .string("Tokyo")]))
+
+        let stored = configuration.transform(record, context)
+
+        XCTAssertEqual(stored.object?["name"], .string("Tokyo"))
+        XCTAssertEqual(configuration.storedID(stored), "s1")
+    }
+}

--- a/Sources/JSONSchemaFormTests/JSONSchemaForm+ForeignKeyTests.swift
+++ b/Sources/JSONSchemaFormTests/JSONSchemaForm+ForeignKeyTests.swift
@@ -1,0 +1,252 @@
+import JSONSchema
+import SwiftUI
+import ViewInspector
+import XCTest
+
+@testable import JSONSchemaForm
+
+/// Simple stub client for rendering tests.
+@MainActor
+private final class StubSearchClient: ForeignKeySearchClient {
+    var page = ForeignKeyPage(items: [], nextCursor: nil)
+    var resolveResult: ForeignKeyItem?
+
+    func search(endpoint: String, query: String?, cursor: String?) async throws -> ForeignKeyPage {
+        page
+    }
+
+    func resolve(endpoint: String, id: String) async throws -> ForeignKeyItem? {
+        resolveResult
+    }
+}
+
+final class JSONSchemaFormForeignKeyTests: XCTestCase {
+
+    private let schemaJSON = """
+        {
+            "type": "object",
+            "properties": {
+                "stationId": { "type": "string", "title": "Station" }
+            }
+        }
+        """
+
+    private let uiSchema: [String: Any] = [
+        "stationId": [
+            "ui:widget": "foreign-key",
+            "ui:options": [
+                "endpoint": "stations",
+                "searchable": true,
+                "accessibility_id": "form.route-station.stationId",
+            ],
+        ]
+    ]
+
+    @MainActor
+    func testForeignKeyWidgetRendersNavigationLinkRow() async throws {
+        let schema = try JSONSchema(jsonString: schemaJSON)
+        let data = Binding(wrappedValue: FormData.object(properties: [
+            "stationId": .string("")
+        ]))
+        let form = JSONSchemaForm(
+            schema: schema,
+            uiSchema: uiSchema,
+            formData: data,
+            foreignKey: ForeignKeyConfiguration(client: StubSearchClient())
+        )
+
+        let row = try form.inspect().find(viewWithId: "root_stationId_foreignkey")
+        XCTAssertNotNil(row)
+        let link = try row.find(ViewType.NavigationLink.self)
+        XCTAssertNotNil(link)
+
+        // The row shows the field title and "None" for an empty selection.
+        XCTAssertNoThrow(try row.find(text: "Station"))
+        XCTAssertNoThrow(try row.find(text: "None"))
+    }
+
+    @MainActor
+    func testForeignKeyRowShowsStoredIDBeforeResolve() async throws {
+        let schema = try JSONSchema(jsonString: schemaJSON)
+        let data = Binding(wrappedValue: FormData.object(properties: [
+            "stationId": .string("station-42")
+        ]))
+        let form = JSONSchemaForm(
+            schema: schema,
+            uiSchema: uiSchema,
+            formData: data,
+            foreignKey: ForeignKeyConfiguration(client: StubSearchClient())
+        )
+
+        // Before (or without) resolve, the raw stored id is displayed.
+        let row = try form.inspect().find(viewWithId: "root_stationId_foreignkey")
+        XCTAssertNoThrow(try row.find(text: "station-42"))
+    }
+
+    @MainActor
+    func testWithoutConfigurationFallsBackToStringField() async throws {
+        let schema = try JSONSchema(jsonString: schemaJSON)
+        let data = Binding(wrappedValue: FormData.object(properties: [
+            "stationId": .string("station-42")
+        ]))
+        let form = JSONSchemaForm(
+            schema: schema,
+            uiSchema: uiSchema,
+            formData: data
+        )
+
+        // No foreignKey configuration — a plain text input renders instead.
+        let textWidget = try form.inspect().find(viewWithId: "root_stationId_text")
+        let textField = try textWidget.find(ViewType.TextField.self)
+        XCTAssertEqual(try textField.input(), "station-42")
+        XCTAssertThrowsError(
+            try form.inspect().find(ViewType.NavigationLink.self))
+    }
+
+    @MainActor
+    func testWithoutEndpointFallsBackToStringField() async throws {
+        let schema = try JSONSchema(jsonString: schemaJSON)
+        let data = Binding(wrappedValue: FormData.object(properties: [
+            "stationId": .string("x")
+        ]))
+        let noEndpointUiSchema: [String: Any] = [
+            "stationId": ["ui:widget": "foreign-key"]
+        ]
+        let form = JSONSchemaForm(
+            schema: schema,
+            uiSchema: noEndpointUiSchema,
+            formData: data,
+            foreignKey: ForeignKeyConfiguration(client: StubSearchClient())
+        )
+
+        XCTAssertNotNil(try form.inspect().find(viewWithId: "root_stationId_text"))
+        XCTAssertThrowsError(
+            try form.inspect().find(ViewType.NavigationLink.self))
+    }
+
+    @MainActor
+    func testAppRegisteredWidgetOverridesBuiltInForeignKey() async throws {
+        let schema = try JSONSchema(jsonString: schemaJSON)
+        let data = Binding(wrappedValue: FormData.object(properties: [
+            "stationId": .string("")
+        ]))
+        let form = JSONSchemaForm(
+            schema: schema,
+            uiSchema: uiSchema,
+            formData: data,
+            widgets: [
+                "foreign-key": { _ in AnyView(Text("custom-relation-widget")) }
+            ],
+            foreignKey: ForeignKeyConfiguration(client: StubSearchClient())
+        )
+
+        XCTAssertNoThrow(try form.inspect().find(text: "custom-relation-widget"))
+        XCTAssertThrowsError(
+            try form.inspect().find(viewWithId: "root_stationId_foreignkey"))
+    }
+
+    @MainActor
+    func testNullableAnyOfForeignKeyRendersRow() async throws {
+        let nullableSchemaJSON = """
+            {
+                "type": "object",
+                "properties": {
+                    "stationId": {
+                        "anyOf": [
+                            { "type": "string", "title": "Station" },
+                            { "type": "null" }
+                        ]
+                    }
+                }
+            }
+            """
+        let schema = try JSONSchema(jsonString: nullableSchemaJSON)
+        let data = Binding(wrappedValue: FormData.object(properties: [
+            "stationId": .string("")
+        ]))
+        let form = JSONSchemaForm(
+            schema: schema,
+            uiSchema: uiSchema,
+            formData: data,
+            foreignKey: ForeignKeyConfiguration(client: StubSearchClient())
+        )
+
+        let row = try form.inspect().find(viewWithId: "root_stationId_foreignkey")
+        XCTAssertNotNil(try row.find(ViewType.NavigationLink.self))
+    }
+
+    @MainActor
+    func testPickerSelectionWritesTransformedValue() async throws {
+        let client = StubSearchClient()
+        client.page = ForeignKeyPage(
+            items: [ForeignKeyItem(id: "s9", title: "Osaka", subtitle: "Kansai")],
+            nextCursor: nil)
+        let configuration = ForeignKeyConfiguration(client: client)
+        let schema = try JSONSchema(jsonString: #"{"type": "string"}"#)
+        let context = ForeignKeyFieldContext(
+            id: "root_stationId", propertyName: "stationId",
+            endpoint: "stations", schema: schema, uiOptions: nil)
+        let data = Binding(wrappedValue: FormData.string(""))
+        var picked: ForeignKeyItem?
+
+        // Inject a preloaded model so rows are inspectable without driving
+        // the async .task.
+        let model = ForeignKeyPickerModel(
+            client: client, endpoint: "stations", searchable: true)
+        await model.load(reset: true)
+
+        let picker = ForeignKeyPickerView(
+            title: "Station",
+            configuration: configuration,
+            context: context,
+            searchable: true,
+            required: true,
+            formData: data,
+            onPicked: { picked = $0 },
+            model: model
+        )
+
+        // Tapping a row runs the transform, writes the value, and reports
+        // the picked item.
+        let row = try picker.inspect().find(button: "Osaka")
+        try row.tap()
+
+        XCTAssertEqual(data.wrappedValue, .string("s9"))
+        XCTAssertEqual(picked?.id, "s9")
+    }
+
+    @MainActor
+    func testPickerNoneRowClearsOptionalValue() async throws {
+        let client = StubSearchClient()
+        client.page = ForeignKeyPage(
+            items: [ForeignKeyItem(id: "s1", title: "Tokyo")], nextCursor: nil)
+        let configuration = ForeignKeyConfiguration(client: client)
+        let schema = try JSONSchema(jsonString: #"{"type": "string"}"#)
+        let context = ForeignKeyFieldContext(
+            id: "root_stationId", propertyName: "stationId",
+            endpoint: "stations", schema: schema, uiOptions: nil)
+        let data = Binding(wrappedValue: FormData.string("s1"))
+        var picked: ForeignKeyItem? = ForeignKeyItem(id: "sentinel", title: "sentinel")
+
+        let model = ForeignKeyPickerModel(
+            client: client, endpoint: "stations", searchable: true)
+        await model.load(reset: true)
+
+        let picker = ForeignKeyPickerView(
+            title: "Station",
+            configuration: configuration,
+            context: context,
+            searchable: true,
+            required: false,
+            formData: data,
+            onPicked: { picked = $0 },
+            model: model
+        )
+
+        let noneRow = try picker.inspect().find(button: "None")
+        try noneRow.tap()
+
+        XCTAssertEqual(data.wrappedValue, .null)
+        XCTAssertNil(picked)
+    }
+}

--- a/readme.md
+++ b/readme.md
@@ -176,6 +176,76 @@ let advancedSchema: JSONSchema = .object(
 )
 ```
 
+### Foreign-Key Fields
+
+Fields marked `ui:widget: "foreign-key"` render as a row that pushes a dedicated,
+searchable, cursor-paginated picker page (the form must be inside a
+`NavigationStack`). The library stays network-agnostic: you inject a search
+client so requests carry your app's authentication, and a transform that decides
+what gets stored (just the id, or the full object).
+
+The field's `ui:options` describe the data source:
+
+```json
+{
+    "stationId": {
+        "ui:widget": "foreign-key",
+        "ui:options": {
+            "endpoint": "stations",
+            "searchable": true
+        }
+    }
+}
+```
+
+- `endpoint` (required): opaque token passed verbatim to your client — typically a resource name or path.
+- `searchable` (default `true`): set `false` to hide the search bar for endpoints without text search.
+- `accessibility_id` (optional): applied to the row via `accessibilityIdentifier`.
+
+Implement the client and pass a `ForeignKeyConfiguration` to the form:
+
+```swift
+@MainActor
+final class MySearchClient: ForeignKeySearchClient {
+    func search(endpoint: String, query: String?, cursor: String?) async throws -> ForeignKeyPage {
+        let page = try await api.list(endpoint, query: query, cursor: cursor) // your authenticated API
+        return ForeignKeyPage(
+            items: page.items.map { ForeignKeyItem(id: $0.id, title: $0.name, subtitle: $0.detail) },
+            nextCursor: page.nextCursor
+        )
+    }
+
+    // Optional: resolve a stored id to a display title for the field row.
+    func resolve(endpoint: String, id: String) async throws -> ForeignKeyItem? {
+        let record = try await api.get(endpoint, id: id)
+        return ForeignKeyItem(id: record.id, title: record.name)
+    }
+}
+
+JSONSchemaForm(
+    schema: schema,
+    uiSchema: uiSchema,
+    formData: $formData,
+    foreignKey: ForeignKeyConfiguration(client: MySearchClient())
+)
+```
+
+By default the picked item's id is stored as a string. APIs that expect the full
+object can customize the transform (and teach the library how to read the id
+back out for display and selection highlighting):
+
+```swift
+ForeignKeyConfiguration(
+    client: MySearchClient(),
+    transform: { item, context in item.raw ?? .string(item.id) },
+    storedID: { value in value.object?["id"]?.string }
+)
+```
+
+Fields with `ui:widget: "foreign-key"` fall back to a plain string input when no
+`foreignKey` configuration (or no `endpoint`) is provided, and an app-registered
+`widgets["foreign-key"]` entry overrides the built-in field entirely.
+
 ## Available Props
 
 The `JSONSchemaForm` component accepts the following properties:
@@ -195,6 +265,8 @@ The `JSONSchemaForm` component accepts the following properties:
 | `disabled` | `Bool` | Whether the entire form is disabled (default: false) |
 | `readonly` | `Bool` | Whether the entire form is read-only (default: false) |
 | `customValidate` | `((Any?, inout [String: Any]) -> Void)?` | Custom validation function |
+| `widgets` | `[String: JSONSchemaFormWidget]` | Custom widgets keyed by `ui:widget` name |
+| `foreignKey` | `ForeignKeyConfiguration?` | Search client + transform for `ui:widget: "foreign-key"` fields |
 | `idPrefix` | `String` | Prefix for form field IDs (default: "root") |
 | `idSeparator` | `String` | Separator for nested field IDs (default: "_") |
 


### PR DESCRIPTION
## Summary
- Adds a first-class `foreign-key` field: `ui:widget: "foreign-key"` renders a row that pushes a dedicated picker page with a search bar and cursor-based lazy pagination (requires a `NavigationStack`).
- New public API: `ForeignKeySearchClient` (app-injected, so requests carry the app's auth), `ForeignKeyConfiguration` with a selected-item `transform` (store the id or the full object) and `storedID` reader, `ForeignKeyItem`/`ForeignKeyPage`, and a `foreignKey:` parameter on `JSONSchemaForm`.
- `ui:options` contract: `endpoint` (opaque token passed to the client), `searchable` (hides the search bar when false), `accessibility_id` (row identifier).
- Graceful fallbacks: no configuration or no endpoint → plain string input; an app-registered `widgets["foreign-key"]` still overrides the built-in field.
- The stored id resolves to a display title via an optional `resolve(endpoint:id:)` (single get-by-id instead of loading the whole collection).

## Tests
- `ForeignKeyPickerModelTests": first load, trimmed/gated search, cursor append, last-row pagination trigger, stale-generation drop (gated in-flight request), error surfacing, default + custom transform round-trips.
- `JSONSchemaForm+ForeignKeyTests` (ViewInspector): row + NavigationLink rendering, stored-id display, fallback without configuration/endpoint, app-widget override, nullable anyOf wrapper, picker row selection and None-row clearing.
- Full suite: 271 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)